### PR TITLE
Move from Java EE to Jakarta EE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>17</source>
+					<target>17</target>
 					<encoding>UTF-8</encoding>
 					<optimize>true</optimize>
 				</configuration>
@@ -110,15 +110,15 @@
 	</build>
 
 	<properties>
-		<tapestry-release-version>5.7.2</tapestry-release-version>
-		<resteasy-version>4.6.0.Final</resteasy-version>
+		<tapestry-release-version>5.9.0</tapestry-release-version>
+		<resteasy-version>6.2.12.Final</resteasy-version>
 	</properties>
 
 	<dependencies>
 
 		<dependency>
 			<groupId>org.apache.tapestry</groupId>
-			<artifactId>tapestry-core</artifactId>
+			<artifactId>tapestry-core-jakarta</artifactId>
 			<version>${tapestry-release-version}</version>
 		</dependency>
 
@@ -147,9 +147,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>3.1.0</version>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>6.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/org/tynamo/resteasy/Application.java
+++ b/src/main/java/org/tynamo/resteasy/Application.java
@@ -4,7 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Collection;
 
-public class Application extends javax.ws.rs.core.Application
+public class Application extends jakarta.ws.rs.core.Application
 {
 	private Set<Object> singletons = new HashSet<Object>();
 	private Set<Class<?>> empty = new HashSet<Class<?>>();

--- a/src/main/java/org/tynamo/resteasy/JSAPIRequestFilter.java
+++ b/src/main/java/org/tynamo/resteasy/JSAPIRequestFilter.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.tapestry5.http.services.ApplicationGlobals;
 import org.apache.tapestry5.http.services.HttpServletRequestFilter;

--- a/src/main/java/org/tynamo/resteasy/ResteasyModule.java
+++ b/src/main/java/org/tynamo/resteasy/ResteasyModule.java
@@ -3,7 +3,7 @@ package org.tynamo.resteasy;
 
 import java.util.Collection;
 
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.Provider;
 
 import org.apache.tapestry5.commons.Configuration;
 import org.apache.tapestry5.commons.MappedConfiguration;
@@ -34,7 +34,7 @@ public class ResteasyModule
 		// Use service builder methods (example below) when the implementation
 		// is provided inline, or requires more initialization than simply
 		// invoking the constructor.
-		binder.bind(javax.ws.rs.core.Application.class, org.tynamo.resteasy.Application.class);
+		binder.bind(jakarta.ws.rs.core.Application.class, org.tynamo.resteasy.Application.class);
 		binder.bind(HttpServletRequestFilter.class, ResteasyRequestFilter.class).withId("ResteasyRequestFilter");
 		binder.bind(HttpServletRequestFilter.class, JSAPIRequestFilter.class).withId("JSAPIRequestFilter");
 	}
@@ -58,7 +58,7 @@ public class ResteasyModule
 		configuration.add(ResteasySymbols.CORS_ENABLED, false);
 	}
 
-	@Contribute(javax.ws.rs.core.Application.class)
+	@Contribute(jakarta.ws.rs.core.Application.class)
 	public static void javaxWsRsCoreApplication(Configuration<Object> singletons,
 	                                            ObjectLocator locator,
 	                                            ResteasyPackageManager resteasyPackageManager,

--- a/src/main/java/org/tynamo/resteasy/ResteasyRequestFilter.java
+++ b/src/main/java/org/tynamo/resteasy/ResteasyRequestFilter.java
@@ -4,11 +4,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.ext.Provider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ext.Provider;
 
 import org.apache.tapestry5.SymbolConstants;
 import org.apache.tapestry5.commons.util.TimeInterval;

--- a/src/main/java/org/tynamo/resteasy/TapestryResteasyBootstrap.java
+++ b/src/main/java/org/tynamo/resteasy/TapestryResteasyBootstrap.java
@@ -3,7 +3,7 @@ package org.tynamo.resteasy;
 import org.apache.tapestry5.ioc.services.SymbolSource;
 import org.jboss.resteasy.plugins.server.servlet.ListenerBootstrap;
 
-import javax.servlet.ServletContext;
+import jakarta.servlet.ServletContext;
 
 public class TapestryResteasyBootstrap extends ListenerBootstrap {
 

--- a/src/test/java/org/tynamo/resteasy/DisableAutoScanTest.java
+++ b/src/test/java/org/tynamo/resteasy/DisableAutoScanTest.java
@@ -23,7 +23,7 @@ public class DisableAutoScanTest
 		Registry registry = builder.build();
 		registry.performRegistryStartup();
 
-		javax.ws.rs.core.Application app = registry.getService(javax.ws.rs.core.Application.class);
+		jakarta.ws.rs.core.Application app = registry.getService(jakarta.ws.rs.core.Application.class);
 		Assert.assertEquals(app.getSingletons().size(), 5, "there are five services");
 
 		registry.shutdown();
@@ -44,7 +44,7 @@ public class DisableAutoScanTest
 		Registry registry = builder.build();
 		registry.performRegistryStartup();
 
-		javax.ws.rs.core.Application app = registry.getService(javax.ws.rs.core.Application.class);
+		jakarta.ws.rs.core.Application app = registry.getService(jakarta.ws.rs.core.Application.class);
 		Assert.assertEquals(app.getSingletons().size(), 2, "there are two services");
 
 		registry.shutdown();

--- a/src/test/java/org/tynamo/resteasy/integration/ResteasyIntegrationTest.java
+++ b/src/test/java/org/tynamo/resteasy/integration/ResteasyIntegrationTest.java
@@ -1,9 +1,9 @@
 package org.tynamo.resteasy.integration;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.ClientBuilder;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/src/test/java/org/tynamo/resteasy/rest/AutodiscoverableInjectableResource.java
+++ b/src/test/java/org/tynamo/resteasy/rest/AutodiscoverableInjectableResource.java
@@ -1,6 +1,6 @@
 package org.tynamo.resteasy.rest;
 
-import javax.ws.rs.Path;
+import jakarta.ws.rs.Path;
 
 @Path("/bound")
 public interface AutodiscoverableInjectableResource

--- a/src/test/java/org/tynamo/resteasy/rest/AutodiscoverableNotBoundButReloadableResource.java
+++ b/src/test/java/org/tynamo/resteasy/rest/AutodiscoverableNotBoundButReloadableResource.java
@@ -1,6 +1,6 @@
 package org.tynamo.resteasy.rest;
 
-import javax.ws.rs.Path;
+import jakarta.ws.rs.Path;
 
 @Path("/notbound")
 public interface AutodiscoverableNotBoundButReloadableResource

--- a/src/test/java/org/tynamo/resteasy/rest/EchoResource.java
+++ b/src/test/java/org/tynamo/resteasy/rest/EchoResource.java
@@ -1,7 +1,7 @@
 package org.tynamo.resteasy.rest;
 
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
 
 @Path("/echo")
 public class EchoResource

--- a/src/test/java/org/tynamo/resteasy/services/AppModule.java
+++ b/src/test/java/org/tynamo/resteasy/services/AppModule.java
@@ -36,7 +36,7 @@ public class AppModule
 	 *          T5 service to be contributed as a REST resource
 	 * 
 	 */
-	@Contribute(javax.ws.rs.core.Application.class)
+	@Contribute(jakarta.ws.rs.core.Application.class)
 	public static void contributeApplication(Configuration<Object> singletons,
 	                                         ReloadableEchoResource reloadableEchoResource)
 	{

--- a/src/test/java/org/tynamo/resteasy/ws/ReloadableEchoResource.java
+++ b/src/test/java/org/tynamo/resteasy/ws/ReloadableEchoResource.java
@@ -1,10 +1,10 @@
 package org.tynamo.resteasy.ws;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 
 @Path("/echo")
 public interface ReloadableEchoResource

--- a/src/test/java/org/tynamo/resteasy/ws/ReloadableEchoResourceImpl.java
+++ b/src/test/java/org/tynamo/resteasy/ws/ReloadableEchoResourceImpl.java
@@ -2,7 +2,7 @@ package org.tynamo.resteasy.ws;
 
 import org.apache.tapestry5.json.JSONObject;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public class ReloadableEchoResourceImpl implements ReloadableEchoResource
 {

--- a/src/test/java/org/tynamo/resteasy/ws/autobuild/PingResource.java
+++ b/src/test/java/org/tynamo/resteasy/ws/autobuild/PingResource.java
@@ -1,9 +1,9 @@
 package org.tynamo.resteasy.ws.autobuild;
 
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 
 @Path("/ping")
 public class PingResource


### PR DESCRIPTION
Change all references from “javax” to “jakarta” to support Jakarta EE. Additionally, change the Tapestry dependency to “tapestry-core-jakarta”. Update Tapestry to version 5.9 and RESTEasy to 6.2.12.