### PR TITLE
Update RESTEasy to 6.2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
 	</build>
 
 	<properties>
-		<tapestry-release-version>5.9.0</tapestry-release-version>
-		<resteasy-version>6.2.12.Final</resteasy-version>
+		<tapestry-release-version>5.9.1</tapestry-release-version>
+		<resteasy-version>6.2.16.Final</resteasy-version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
When I use this library in a project that pulls in RESTEasy in version 6.2.16, I get the following error at startup:

```
EMM 8638 [http-nio-8080-exec-1] ERROR org.apache.tapestry5.ioc.Registry  - Error invoking constructor public org.tynamo.resteasy.JSAPIRequestFilter(java.lang.String,org.apache.tapestry5.http.services.ApplicationGlobals,org.slf4j.Logger) throws java.lang.Exception: 'void org.jboss.resteasy.jsapi.ServiceRegistry.<init>(org.jboss.resteasy.jsapi.ServiceRegistry, org.jboss.resteasy.core.ResourceMethodRegistry, org.jboss.resteasy.spi.ResteasyProviderFactory, org.jboss.resteasy.core.ResourceLocatorInvoker)'
EMM 8638 [http-nio-8080-exec-1] ERROR org.apache.tapestry5.ioc.Registry  - Operations trace:
EMM 8638 [http-nio-8080-exec-1] ERROR org.apache.tapestry5.ioc.Registry  - [ 1] Realizing service JSAPIRequestFilter
EMM 8639 [http-nio-8080-exec-1] ERROR org.apache.tapestry5.ioc.Registry  - [ 2] Instantiating service JSAPIRequestFilter implementation via org.tynamo.resteasy.JSAPIRequestFilter(String, ApplicationGlobals, Logger) (at JSAPIRequestFilter.java:35) via org.tynamo.resteasy.ResteasyModule.bind(ServiceBinder) (at ResteasyModule.java:37)
EMM 8639 [http-nio-8080-exec-1] ERROR org.apache.tapestry5.ioc.Registry  - [ 3] Invoking constructor org.tynamo.resteasy.JSAPIRequestFilter(String, ApplicationGlobals, Logger) (at JSAPIRequestFilter.java:35) via org.tynamo.resteasy.ResteasyModule.bind(ServiceBinder) (at ResteasyModule.java:37) (for service 'JSAPIRequestFilter')
EMM 8641 [http-nio-8080-exec-1] ERROR org.tynamo.resteasy.ResteasyModule.JSAPIRequestFilter  - Construction of service JSAPIRequestFilter failed: Error invoking constructor public org.tynamo.resteasy.JSAPIRequestFilter(java.lang.String,org.apache.tapestry5.http.services.ApplicationGlobals,org.slf4j.Logger) throws java.lang.Exception: 'void org.jboss.resteasy.jsapi.ServiceRegistry.<init>(org.jboss.resteasy.jsapi.ServiceRegistry, org.jboss.resteasy.core.ResourceMethodRegistry, org.jboss.resteasy.spi.ResteasyProviderFactory, org.jboss.resteasy.core.ResourceLocatorInvoker)'
org.apache.tapestry5.ioc.internal.OperationException: Error invoking constructor public org.tynamo.resteasy.JSAPIRequestFilter(java.lang.String,org.apache.tapestry5.http.services.ApplicationGlobals,org.slf4j.Logger) throws java.lang.Exception: 'void org.jboss.resteasy.jsapi.ServiceRegistry.<init>(org.jboss.resteasy.jsapi.ServiceRegistry, org.jboss.resteasy.core.ResourceMethodRegistry, org.jboss.resteasy.spi.ResteasyProviderFactory, org.jboss.resteasy.core.ResourceLocatorInvoker)'
[…]
Caused by: java.lang.NoSuchMethodError: 'void org.jboss.resteasy.jsapi.ServiceRegistry.<init>(org.jboss.resteasy.jsapi.ServiceRegistry, org.jboss.resteasy.core.ResourceMethodRegistry, org.jboss.resteasy.spi.ResteasyProviderFactory, org.jboss.resteasy.core.ResourceLocatorInvoker)'
        at org.tynamo.resteasy.JSAPIRequestFilter.<init>(JSAPIRequestFilter.java:49)
        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
        at org.apache.tapestry5.ioc.internal.util.ConstructorInvoker.invoke(ConstructorInvoker.java:50)
        ... 93 more
```

Compiling this library against RESTEasy 6.2.16 fixes it. This PR therefore updates the RESTEasy dependency to version 6.2.16—and Tapestry to 5.9.1.